### PR TITLE
Install script and NPM package

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -60,7 +60,7 @@ jobs:
     build-and-publish-npm:
         name: Build and publish to npm
         runs-on: ubuntu-latest
-        #todo: if: ${{ github.event.release.prerelease == false }}
+        if: ${{ github.event.release.prerelease == false }}
         steps:
             - name: Checkout
               uses: actions/checkout@v3

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -75,10 +75,11 @@ jobs:
               with:
                   node-version: "20.x"
             - run: npm ci
-            - run: npm publish  # includes build
+            - run: npm publish --access public  # includes build
               env:
                 FILEN_CLI_CRYPTO_BASE_KEY: ${{ secrets.FILEN_CLI_CRYPTO_BASE_KEY }}
                 FILEN_IS_NPM_PACKAGE: true
+                NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
     build-and-publish-docker:
         name: Build docker image

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -82,6 +82,7 @@ jobs:
     build-and-publish-docker:
         name: Build docker image
         runs-on: ubuntu-latest
+        if: ${{ github.event.release.prerelease == false }}
         steps:
             - uses: actions/checkout@v3
             - name: Set version

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -74,6 +74,7 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version: "20.x"
+                  registry-url: "https://registry.npmjs.org"
             - run: npm ci
             - run: npm publish --access public  # includes build
               env:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -77,6 +77,7 @@ jobs:
             - run: npm ci
             - run: npm publish  # includes build
               env:
+                FILEN_CLI_CRYPTO_BASE_KEY: ${{ secrets.FILEN_CLI_CRYPTO_BASE_KEY }}
                 FILEN_IS_NPM_PACKAGE: true
 
     build-and-publish-docker:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -60,6 +60,7 @@ jobs:
     build-and-publish-npm:
         name: Build and publish to npm
         runs-on: ubuntu-latest
+        #todo: if: ${{ github.event.release.prerelease == false }}
         steps:
             - name: Checkout
               uses: actions/checkout@v3
@@ -74,8 +75,9 @@ jobs:
               with:
                   node-version: "20.x"
             - run: npm ci
-            - run: npm run build
-            - run: npm publish
+            - run: npm publish  # includes build
+              env:
+                FILEN_IS_NPM_PACKAGE: true
 
     build-and-publish-docker:
         name: Build docker image

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -57,6 +57,26 @@ jobs:
                       dist/filen-cli-${{ github.event.release.tag_name }}-linux-arm64
                       dist/filen-cli-${{ github.event.release.tag_name }}-macos-arm64
 
+    build-and-publish-npm:
+        name: Build and publish to npm
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+            - name: Set version
+              uses: jacobtomlinson/gha-find-replace@v3
+              with:
+                  include: "package.json"
+                  find: '"version": "0.0.0"'
+                  replace: '"version": "${{ github.event.release.tag_name }}"'
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "20.x"
+            - run: npm ci
+            - run: npm run build
+            - run: npm publish
+
     build-and-publish-docker:
         name: Build docker image
         runs-on: ubuntu-latest

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
 	"files.eol": "\n",
 	"editor.formatOnPaste": false,
-	"editor.formatOnSave": true,
+	"editor.formatOnSave": false,
 	"editor.formatOnType": false,
 	"editor.defaultFormatter": "esbenp.prettier-vscode",
 	"editor.codeActionsOnSave": {

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Use the `--auto-update` flag to skip the confirmation prompt and update automati
 
 You can always install any version using `filen install <version>`, `filen install latest` or `filen install canary`.
 
+The CLI is also available as an NPM package, which can be installed with `npm install --global @filen/cli` and then invoked as `filen`. The NPM repository always contains the latest canary releases (see below).
+
 ### Canary releases
 
 If you want to be among the first to try out new features and fixes, you can enable canary releases,

--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ The Filen CLI provides a set of useful tools for interacting with the cloud:
 
 # Installation and updates
 
-You can download the latest binaries from the [release page](https://github.com/FilenCloudDienste/filen-cli/releases/latest).
+You can download the latest binaries from the [release page](https://github.com/FilenCloudDienste/filen-cli/releases/latest), or execute the install script (Linux and macOS):
+```console
+curl -s https://raw.githubusercontent.com/FilenCloudDienste/filen-cli/refs/heads/main/install.sh | bash
+```
+
 Docker images are also available as [filen/cli](https://hub.docker.com/repository/docker/filen/cli) (see [below](#using-docker)).
 
 The Filen CLI includes an automatic updater that checks for a new release every time the CLI is invoked

--- a/injectBuildInfo.mjs
+++ b/injectBuildInfo.mjs
@@ -4,6 +4,7 @@ import * as fs from "fs"
 
 const version = JSON.parse(fs.readFileSync("package.json").toString()).version
 const isContainer = process.env.FILEN_IS_CONTAINER === "true"
+const isNPMPackage = process.env.FILEN_IS_NPM_PACKAGE === "true"
 const key = process.env.FILEN_CLI_CRYPTO_BASE_KEY ?? fs.readFileSync("key").toString().split("\n")[0]
 
 const injectionFile = "build/buildInfo.js"
@@ -11,6 +12,7 @@ let content = fs.readFileSync(injectionFile).toString()
 const buildInfo = {
 	VERSION: `"${version}"`,
 	IS_CONTAINER: `${isContainer}`,
+	IS_NPM_PACKAGE: `${isNPMPackage}`,
 	CRYPTO_BASE_KEY: `"${key}"`,
 }
 Object.entries(buildInfo).forEach(entry => {

--- a/install.sh
+++ b/install.sh
@@ -2,23 +2,23 @@
 
 # check if filen-cli is already installed
 if [[ ! -z $(which filen) ]] ; then
-    echo "Filen CLI is already installed"
-    echo "You can install a different version using \`filen install <version>\` or \`filen install latest\`"
-    echo "To uninstall, delete ~/.filen-cli and revert changes to ~/.profile"
+  echo "Filen CLI is already installed"
+  echo "You can install a different version using \`filen install <version>\` or \`filen install latest\`"
+  echo "To uninstall, delete ~/.filen-cli and revert changes to your shell profile(s)"
 else
 
   # determine platform as "linux" or "macos"
   if [[ "$(uname -s)" == "Linux" ]] ; then
-      platform=linux
+    platform=linux
   elif [[ "$(uname -s)" == "Darwin" ]] ; then
-      platform=macos
+    platform=macos
   fi
 
   # determine architecture as "x64" or "arm64"
   if [[ "$(uname -m)" == "aarch64" || "$(uname -m)" == "arm64" ]] ; then
-      arch=arm64
+    arch=arm64
   else
-      arch=x64
+    arch=x64
   fi
 
   # fetch release info
@@ -37,15 +37,24 @@ else
   chmod +x ~/.filen-cli/bin/filen
 
   # add to PATH
-  if [[ $PATH == *"~/.filen-cli"* ]] ; then
-      echo "\$PATH already contains ~/.filen-cli"
+  if [[ $PATH == *$(echo ~)/\.filen-cli* ]] ; then
+    echo "\$PATH already contains ~/.filen-cli"
   else
-      export PATH=$PATH:~/.filen-cli/bin
-      printf "\n\n# filen-cli\nPATH=\$PATH:~/.filen-cli/bin\n" >> ~/.profile
-      echo "Added ~/.filen-cli/bin to \$PATH in ~/.profile"
+    export PATH=$PATH:~/.filen-cli/bin
+    profileFileFound=0
+    for profileFile in ~/.bashrc ~/.bash_profile ~/.zshrc ~/.profile ; do
+      if [[ -f $profileFile ]] ; then
+        profileFileFound=1
+        printf "\n\n# filen-cli\nPATH=\$PATH:~/.filen-cli/bin\n" >> $profileFile
+        echo "Added ~/.filen-cli/bin to \$PATH in $profileFile"
+      fi
+    done
+    if [[ $profileFileFound == "0" ]] ; then
+      echo "ERR: No shell profile file found (checked: ~/.bashrc ~/.bash_profile ~/.zshrc ~/.profile)"
+    fi
   fi
   echo "Filen CLI installed as \`filen\` (you might need to restart your shell)"
 
-  echo "To uninstall, delete ~/.filen-cli and revert changes to ~/.profile"
+  echo "To uninstall, delete ~/.filen-cli and revert changes to your shell profile(s)"
 
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# determine platform as "linux" or "macos"
+if [[ "$(uname -s)" == "Linux" ]] ; then
+    platform=linux
+elif [[ "$(uname -s)" == "Darwin" ]] ; then
+    platform=macos
+fi
+
+# determine architecture as "x64" or "arm64"
+if [[ "$(uname -m)" == "aarch64" || "$(uname -m)" == "arm64" ]] ; then
+    arch=arm64
+else
+    arch=x64
+fi
+
+# fetch release info
+latest_release=$(curl -s https://api.github.com/repos/FilenCloudDienste/filen-cli/releases/latest)
+version=$(echo "$latest_release" | grep "tag_name" | cut -d \" -f 4)
+download_url=$(echo "$latest_release" | grep "browser_download_url.*$platform-$arch" | cut -d \" -f 4)
+
+echo "Installing Filen CLI $version ($platform-$arch)"
+
+# prepare install location ~/.filen-cli
+location=~/.filen-cli
+if [ ! -d $location ] ; then mkdir -p $location/bin ; fi
+
+# download binary and make executable
+echo "Downloading $download_url..."
+curl -o $location/bin/filen -L --progress-bar $download_url
+chmod +x $location/bin/filen
+
+# add to PATH
+if [[ $PATH == *"$location"* ]] ; then
+    echo "\$PATH already contains $location"
+else
+    export PATH=$PATH:$location/bin
+    printf "\n\n# filen-cli\nPATH=\$PATH:$location/bin\n" >> ~/.profile
+    echo "Added $location/bin to \$PATH in ~/.profile"
+fi
+echo "Filen CLI installed as \`filen\` (you might need to restart your shell)"
+
+echo "To uninstall, delete $location and revert changes to ~/.profile"

--- a/install.sh
+++ b/install.sh
@@ -1,43 +1,51 @@
 #!/usr/bin/env bash
 
-# determine platform as "linux" or "macos"
-if [[ "$(uname -s)" == "Linux" ]] ; then
-    platform=linux
-elif [[ "$(uname -s)" == "Darwin" ]] ; then
-    platform=macos
-fi
-
-# determine architecture as "x64" or "arm64"
-if [[ "$(uname -m)" == "aarch64" || "$(uname -m)" == "arm64" ]] ; then
-    arch=arm64
+# check if filen-cli is already installed
+if [[ ! -z $(which filen) ]] ; then
+    echo "Filen CLI is already installed"
+    echo "You can install a different version using \`filen install <version>\` or \`filen install latest\`"
+    echo "To uninstall, delete ~/.filen-cli and revert changes to ~/.profile"
 else
-    arch=x64
+
+  # determine platform as "linux" or "macos"
+  if [[ "$(uname -s)" == "Linux" ]] ; then
+      platform=linux
+  elif [[ "$(uname -s)" == "Darwin" ]] ; then
+      platform=macos
+  fi
+
+  # determine architecture as "x64" or "arm64"
+  if [[ "$(uname -m)" == "aarch64" || "$(uname -m)" == "arm64" ]] ; then
+      arch=arm64
+  else
+      arch=x64
+  fi
+
+  # fetch release info
+  latest_release=$(curl -s https://api.github.com/repos/FilenCloudDienste/filen-cli/releases/latest)
+  version=$(echo "$latest_release" | grep "tag_name" | cut -d \" -f 4)
+  download_url=$(echo "$latest_release" | grep "browser_download_url.*$platform-$arch" | cut -d \" -f 4)
+
+  echo "Installing Filen CLI $version ($platform-$arch)"
+
+  # prepare install location ~/.filen-cli
+  if [ ! -d ~/.filen-cli ] ; then mkdir -p ~/.filen-cli/bin ; fi
+
+  # download binary and make executable
+  echo "Downloading $download_url..."
+  curl -o ~/.filen-cli/bin/filen -L --progress-bar $download_url
+  chmod +x ~/.filen-cli/bin/filen
+
+  # add to PATH
+  if [[ $PATH == *"~/.filen-cli"* ]] ; then
+      echo "\$PATH already contains ~/.filen-cli"
+  else
+      export PATH=$PATH:~/.filen-cli/bin
+      printf "\n\n# filen-cli\nPATH=\$PATH:~/.filen-cli/bin\n" >> ~/.profile
+      echo "Added ~/.filen-cli/bin to \$PATH in ~/.profile"
+  fi
+  echo "Filen CLI installed as \`filen\` (you might need to restart your shell)"
+
+  echo "To uninstall, delete ~/.filen-cli and revert changes to ~/.profile"
+
 fi
-
-# fetch release info
-latest_release=$(curl -s https://api.github.com/repos/FilenCloudDienste/filen-cli/releases/latest)
-version=$(echo "$latest_release" | grep "tag_name" | cut -d \" -f 4)
-download_url=$(echo "$latest_release" | grep "browser_download_url.*$platform-$arch" | cut -d \" -f 4)
-
-echo "Installing Filen CLI $version ($platform-$arch)"
-
-# prepare install location ~/.filen-cli
-location=~/.filen-cli
-if [ ! -d $location ] ; then mkdir -p $location/bin ; fi
-
-# download binary and make executable
-echo "Downloading $download_url..."
-curl -o $location/bin/filen -L --progress-bar $download_url
-chmod +x $location/bin/filen
-
-# add to PATH
-if [[ $PATH == *"$location"* ]] ; then
-    echo "\$PATH already contains $location"
-else
-    export PATH=$PATH:$location/bin
-    printf "\n\n# filen-cli\nPATH=\$PATH:$location/bin\n" >> ~/.profile
-    echo "Added $location/bin to \$PATH in ~/.profile"
-fi
-echo "Filen CLI installed as \`filen\` (you might need to restart your shell)"
-
-echo "To uninstall, delete $location and revert changes to ~/.profile"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
-	"name": "filen-cli",
+	"name": "@filen/cli",
 	"version": "0.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "filen-cli",
+			"name": "@filen/cli",
 			"version": "0.0.0",
 			"license": "AGPLv3",
 			"dependencies": {
 				"@filen/network-drive": "^0.9.40",
-				"@filen/s3": "^0.2.50",
-				"@filen/sdk": "^0.1.191",
-				"@filen/sync": "^0.1.95",
+				"@filen/s3": "^0.2.51",
+				"@filen/sdk": "^0.1.192",
+				"@filen/sync": "^0.1.96",
 				"@filen/webdav": "^0.2.64",
 				"@types/mute-stream": "^0.0.4",
 				"arg": "^5.0.2",
@@ -23,6 +23,9 @@
 				"read": "^4.0.0",
 				"semver": "^7.6.3",
 				"uuid-by-string": "^4.0.0"
+			},
+			"bin": {
+				"filen": "build/index.js"
 			},
 			"devDependencies": {
 				"@types/cli-progress": "^3.11.6",
@@ -1313,6 +1316,15 @@
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
+		"node_modules/@filen/aws4-express": {
+			"version": "0.10.2",
+			"resolved": "https://registry.npmjs.org/@filen/aws4-express/-/aws4-express-0.10.2.tgz",
+			"integrity": "sha512-k8WExS1UZ9uV3uEWinf2cwFeB3AzDy0KnDcrX72Liajl/cU6GIZzLFXOIubsZIBVvz/AXPiX1iEwYAHsvTdlYw==",
+			"license": "SEE LICENSE IN LICENSE",
+			"dependencies": {
+				"express": "^4.21.1"
+			}
+		},
 		"node_modules/@filen/network-drive": {
 			"version": "0.9.40",
 			"resolved": "https://registry.npmjs.org/@filen/network-drive/-/network-drive-0.9.40.tgz",
@@ -1371,14 +1383,14 @@
 			}
 		},
 		"node_modules/@filen/s3": {
-			"version": "0.2.50",
-			"resolved": "https://registry.npmjs.org/@filen/s3/-/s3-0.2.50.tgz",
-			"integrity": "sha512-Gaih6O/gpSLNPRTkYmzdcoUAf/VpDuAdPgbjor9kkb9O2Gg56NY15Qr0ppGp1CmzyQInUeQKHriitIg7Vuzrjg==",
+			"version": "0.2.51",
+			"resolved": "https://registry.npmjs.org/@filen/s3/-/s3-0.2.51.tgz",
+			"integrity": "sha512-rQDPwi0EdMx4CtSZ8mvYDgLFOtIIyPzP0X/gLoK1obG0/pclPkCmipjiDVM4fdEFCojPk8b2QlBSjJQbovM+og==",
 			"license": "AGPLv3",
 			"dependencies": {
-				"@filen/sdk": "^0.1.191",
+				"@filen/aws4-express": "^0.10.2",
+				"@filen/sdk": "^0.1.192",
 				"aws-sdk": "^2.1692.0",
-				"aws4-express": "github:FilenCloudDienste/aws4-express",
 				"body-parser": "^1.20.2",
 				"dayjs": "^1.11.11",
 				"express": "^4.19.2",
@@ -1423,9 +1435,9 @@
 			}
 		},
 		"node_modules/@filen/sdk": {
-			"version": "0.1.191",
-			"resolved": "https://registry.npmjs.org/@filen/sdk/-/sdk-0.1.191.tgz",
-			"integrity": "sha512-JwlDuUKaGMKgX54AHkSVCHKbEappi4S/3qX1CcWY76ZZt/+RDr3AdzMKIvt7hgM9YFAEzByBsnHk/6GloIR6rA==",
+			"version": "0.1.192",
+			"resolved": "https://registry.npmjs.org/@filen/sdk/-/sdk-0.1.192.tgz",
+			"integrity": "sha512-f5YmNdPoKNJ08zHt4k6enuNvDZ95RaTlFQVbhNpKL4GQNza1kbpks7AYJBieGqp7DiWg9HskF2YZ2rKz7oISbQ==",
 			"license": "AGPLv3",
 			"dependencies": {
 				"agentkeepalive": "^4.5.0",
@@ -1497,9 +1509,9 @@
 			}
 		},
 		"node_modules/@filen/sync": {
-			"version": "0.1.95",
-			"resolved": "https://registry.npmjs.org/@filen/sync/-/sync-0.1.95.tgz",
-			"integrity": "sha512-Dsy8blLmmPTE3WrEELWGI2Zrid61cIEbSqVnNNcqb/eyng4onoYhl/xZKtyIA1UmYqhGVS+F25luMHFjMptQaQ==",
+			"version": "0.1.96",
+			"resolved": "https://registry.npmjs.org/@filen/sync/-/sync-0.1.96.tgz",
+			"integrity": "sha512-F5sDXJecSFvK9lecFS9U8n0HdzGzW3CN0XyGY9D1WzJsVSAaMfGXxRQMXAClZ4ey4bvMXgG336Bct2HExOlHSw==",
 			"license": "AGPLv3",
 			"dependencies": {
 				"@filen/sdk": "^0.1.191",
@@ -3403,14 +3415,6 @@
 			"license": "MIT",
 			"bin": {
 				"uuid": "dist/bin/uuid"
-			}
-		},
-		"node_modules/aws4-express": {
-			"version": "0.10.2",
-			"resolved": "git+ssh://git@github.com/FilenCloudDienste/aws4-express.git#b5dcf34d9cbe3fb48aa4641f35ad74ab7cb67f91",
-			"license": "SEE LICENSE IN LICENSE",
-			"dependencies": {
-				"express": "^4.21.1"
 			}
 		},
 		"node_modules/axios": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "filen-cli",
+	"name": "@filen/cli",
 	"version": "0.0.0",
 	"description": "Filen CLI",
 	"main": "build/index.js",
@@ -14,6 +14,10 @@
 		"package-all": "npm run build && node packageAllPlatforms.mjs",
 		"bump-filen-dependencies": "npm i @filen/sdk@latest @filen/sync@latest @filen/webdav@latest @filen/s3@latest @filen/network-drive@latest"
 	},
+	"bin": {
+		"filen": "build/index.js"
+	},
+	"files": [ "build" ],
 	"engines": {
 		"node": "20"
 	},
@@ -28,9 +32,9 @@
 	"license": "AGPLv3",
 	"dependencies": {
 		"@filen/network-drive": "^0.9.40",
-		"@filen/s3": "^0.2.50",
-		"@filen/sdk": "^0.1.191",
-		"@filen/sync": "^0.1.95",
+		"@filen/s3": "^0.2.51",
+		"@filen/sdk": "^0.1.192",
+		"@filen/sync": "^0.1.96",
 		"@filen/webdav": "^0.2.64",
 		"@types/mute-stream": "^0.0.4",
 		"arg": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
 		"package-dev": "npm run build && pkg -t node20 -o dist/filen-cli dist/bundle.js",
 		"package-dev-all": "npm run build && node packageAllPlatforms.mjs dev",
 		"package-all": "npm run build && node packageAllPlatforms.mjs",
-		"bump-filen-dependencies": "npm i @filen/sdk@latest @filen/sync@latest @filen/webdav@latest @filen/s3@latest @filen/network-drive@latest"
+		"bump-filen-dependencies": "npm i @filen/sdk@latest @filen/sync@latest @filen/webdav@latest @filen/s3@latest @filen/network-drive@latest",
+		"prepublishOnly": "node -e \"if (process.env.FILEN_IS_NPM_PACKAGE !== 'true') process.exit(1)\" && npm run build"
 	},
 	"bin": {
 		"filen": "build/index.js"

--- a/src/buildInfo.ts
+++ b/src/buildInfo.ts
@@ -6,10 +6,14 @@ export const version: string = "{{INJECT: VERSION}}"
 // @ts-expect-error will be injected
 export const disableUpdates: boolean = "{{INJECT: IS_CONTAINER}}"
 
+// @ts-expect-error will be injected
+export const isRunningAsNPMPackage: boolean = "{{INJECT: IS_NPM_PACKAGE}}"
+
 export const key: string = "{{INJECT: CRYPTO_BASE_KEY}}"
 
 export function checkInjectedBuildInfo() {
 	return version !== "{{INJECT: VERSION}}"
 		&& (disableUpdates.toString() === "true" || disableUpdates.toString() === "false")
+		&& (isRunningAsNPMPackage.toString() === "true" || isRunningAsNPMPackage.toString() === "false")
 		&& key !== "{{INJECT: CRYPTO_BASE_KEY}}"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import arg from "arg"
 import FilenSDK from "@filen/sdk"
 import path from "path"

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -36,6 +36,11 @@ export class Updater {
 	 * @param autoUpdate the `--auto-update` CLI argument
 	 */
 	public async checkForUpdates(forceUpdateCheck: boolean, autoUpdate: boolean): Promise<void> {
+		if (isRunningAsNPMPackage) {
+			await this.checkNPMRegistryForUpdates()
+			return
+		}
+
 		if ((process.pkg === undefined ? __filename : process.argv[0]!).endsWith(".js")) {
 			outVerbose("Skipping updates for non-binary installation")
 			return
@@ -43,12 +48,6 @@ export class Updater {
 
 		if (version === "0.0.0") {
 			outVerbose("Skipping updates in development environment")
-			return
-		}
-
-		// check NPM registry instead if running as NPM package
-		if (isRunningAsNPMPackage) {
-			await this.checkNPMRegistryForUpdates()
 			return
 		}
 
@@ -140,6 +139,8 @@ export class Updater {
 			if (latestVersion === undefined) throw new Error("latest version not found in NPM registry response")
 			if (latestVersion !== version) {
 				out(`Update available: ${version} -> ${latestVersion} (install via npm i -g @filen/cli@latest)`)
+			} else {
+				outVerbose(`${version} is up to date.`)
 			}
 		} catch (e) {
 			errExit("check NPM registry for updates", e)

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -36,6 +36,13 @@ export class Updater {
 	 * @param autoUpdate the `--auto-update` CLI argument
 	 */
 	public async checkForUpdates(forceUpdateCheck: boolean, autoUpdate: boolean): Promise<void> {
+		if ((process.pkg === undefined ? __filename : process.argv[0]!).endsWith(".js")) {
+			outVerbose("Skipping updates for non-binary installation")
+			return
+		}
+
+		// todo: different update checking when executed as NPM package
+
 		if (version === "0.0.0") {
 			outVerbose("Skipping updates in development environment")
 			return
@@ -260,6 +267,7 @@ export class Updater {
 
 	private async installVersion(currentVersionName: string, publishedVersionName: string, downloadUrl: string) {
 		const selfApplicationFile = process.pkg === undefined ? __filename : process.argv[0]!
+		if (selfApplicationFile.endsWith(".js")) errExit("Updater only supported for CLI binaries")
 		const downloadedFile = path.join(path.dirname(selfApplicationFile), `filen_update_${publishedVersionName}`)
 
 		out("Downloading update...")

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -137,8 +137,8 @@ export class Updater {
 
 			const latestVersion = data["dist-tags"]["latest"]
 			if (latestVersion === undefined) throw new Error("latest version not found in NPM registry response")
-			if (latestVersion !== version) {
-				out(`Update available: ${version} -> ${latestVersion} (install via npm i -g @filen/cli@latest)`)
+			if (semver.neq(latestVersion, version)) {
+				out(`Update available: ${version} -> v${latestVersion} (install via npm i -g @filen/cli@latest)`)
 			} else {
 				outVerbose(`${version} is up to date.`)
 			}

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -132,7 +132,7 @@ export class Updater {
 
 	private async checkNPMRegistryForUpdates() {
 		try {
-			const response = await fetch("https://registry.npmjs.org/filen-cli")
+			const response = await fetch("https://registry.npmjs.org/@filen/cli")
 			if (response.status !== 200) throw new Error(`NPM registry API returned status ${response.status} ${response.statusText}`)
 			const data = await response.json()
 

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -55,6 +55,7 @@ export async function directorySize(path: PathLike) {
 	return (await Promise.all(stats)).reduce((accumulator, { size }) => accumulator + size, 0)
 }
 
+let _platformConfigPath: string | undefined = undefined
 /**
  * Returns the platform-specific directory for storing configuration files.
  * Creates the directory if it doesn't exist.
@@ -63,6 +64,8 @@ export async function directorySize(path: PathLike) {
  * - Unix: `$XDG_CONFIG_HOME/filen-cli` or `~/.config/filen-cli` (or `~/.filen-cli`)
  */
 export function platformConfigPath(): string {
+	if (_platformConfigPath !== undefined) return _platformConfigPath
+
 	// default config path, see https://github.com/jprichardson/ospath/blob/master/index.js
 	let configPath: string = (() => {
 		switch (process.platform) {
@@ -97,6 +100,7 @@ export function platformConfigPath(): string {
 		})
 	}
 
+	_platformConfigPath = configPath
 	return configPath
 }
 


### PR DESCRIPTION
This PR adds the following major features:

- installing the CLI by executing an install script via `curl -s https://raw.githubusercontent.com/FilenCloudDienste/filen-cli/refs/heads/main/install.sh | bash`
- installing the CLI from the NPM package `@filen/cli` via `npm i -g @filen/cli` and invoking it as `filen`